### PR TITLE
Fixed issue with pip install when using python3.6

### DIFF
--- a/integration/int_3Ri_2BhaRi2_3Re_2BhaRe3/tasks/pip_modules.yml
+++ b/integration/int_3Ri_2BhaRi2_3Re_2BhaRe3/tasks/pip_modules.yml
@@ -4,4 +4,3 @@
     name:
       - docker
       - selinux
-    extra_args: --user


### PR DESCRIPTION
Using "--user" argument to pip3 causes issues to the selinux (pip)
module, as it is unable to find the /root/.local/ version of site-packages.